### PR TITLE
Add unit tests for Cancellation and Station controllers

### DIFF
--- a/Tests/WebApi.Tests/Controllers/CancellationControllerTests.cs
+++ b/Tests/WebApi.Tests/Controllers/CancellationControllerTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Commands.BookingCommands;
+using Application.Commands.CancellationCommands;
+using Application.DTOs.BookingDTOs;
+using Application.DTOs.CancellationDTOs;
+using AutoFixture;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using WebApi.Controllers;
+using Xunit;
+
+namespace WebApi.Tests.Controllers
+{
+    public class CancellationControllerTests
+    {
+        private readonly Mock<ISender> _senderMock;
+        private readonly CancellationController _controller;
+        private readonly IFixture _fixture;
+
+        public CancellationControllerTests()
+        {
+            _fixture = new Fixture();
+            _senderMock = new Mock<ISender>();
+            _controller = new CancellationController(_senderMock.Object);
+        }
+
+        [Fact]
+        public async Task CancelBooking_ShouldReturnOkResult_WhenCancellationSucceeds()
+        {
+            // Arrange
+            var cancellationRequest = _fixture.Create<CancellationRequestDTO>();
+            
+            _senderMock
+                .Setup(x => x.Send(It.Is<BookingCancellationCommand>(cmd => 
+                    cmd.cancellationRequest == cancellationRequest), 
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            // Act
+            var result = await _controller.CancelBooking(cancellationRequest);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal("Booking cancelled", okResult.Value);
+            
+            // Verify the command was sent with correct parameters
+            _senderMock.Verify(
+                x => x.Send(
+                    It.Is<BookingCancellationCommand>(cmd => cmd.cancellationRequest == cancellationRequest),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+    }
+}   

--- a/Tests/WebApi.Tests/Controllers/StationControllerTests.cs
+++ b/Tests/WebApi.Tests/Controllers/StationControllerTests.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Commands.StationCommands;
+using Application.DTOs.StationDTOs;
+using AutoFixture;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using WebApi.Controllers;
+using Xunit;
+
+namespace WebApi.Tests.Controllers
+{
+    public class StationControllerTests
+    {
+        private readonly Mock<ISender> _senderMock;
+        private readonly StationController _controller;
+        private readonly IFixture _fixture;
+
+        public StationControllerTests()
+        {
+            _fixture = new Fixture();
+            _senderMock = new Mock<ISender>();
+            _controller = new StationController(_senderMock.Object);
+        }
+
+        [Fact]
+        public async Task GetStationsByQueryAsync_WithValidQuery_ShouldReturnOkResult()
+        {
+            // Arrange
+            var query = "Delhi";
+            var expectedStations = _fixture.CreateMany<DisplayStationDTO>(3).ToList();
+            
+            _senderMock.Setup(x => x.Send(
+                It.Is<GetStationCommand>(cmd => cmd.query == query),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedStations);
+
+            // Act
+            var result = await _controller.GetStationsByQueryAsync(query);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var stations = Assert.IsAssignableFrom<List<DisplayStationDTO>>(okResult.Value);
+            Assert.Equal(expectedStations.Count, stations.Count);
+            
+            _senderMock.Verify(
+                x => x.Send(
+                    It.Is<GetStationCommand>(cmd => cmd.query == query),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public async Task GetStationsByQueryAsync_WithEmptyQuery_ShouldReturnBadRequest(string query)
+        {
+            // Act
+            var result = await _controller.GetStationsByQueryAsync(query);
+
+            // Assert
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal("Station query is empty", badRequestResult.Value);
+            
+            // Verify mediator was not called
+            _senderMock.Verify(
+                x => x.Send(It.IsAny<GetStationCommand>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+    }
+}


### PR DESCRIPTION
Implemented unit tests for `CancellationController` and `StationController` in the `WebApi.Tests.Controllers` namespace. Utilized Moq for mocking the `ISender` interface and AutoFixture for generating test data. Added tests for successful booking cancellation and for handling valid and empty station query scenarios.